### PR TITLE
Implement basic HTTP authentication support

### DIFF
--- a/lib/redfish_client/root.rb
+++ b/lib/redfish_client/root.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "base64"
 require "redfish_client/resource"
 
 module RedfishClient
@@ -9,39 +10,36 @@ module RedfishClient
     # AuthError is raised if the user session cannot be created.
     class AuthError < StandardError; end
 
-    # Token authentication header.
-    AUTH_HEADER = "X-Auth-Token"
+    # Basic and token authentication headers.
+    BASIC_AUTH_HEADER = "Authorization"
+    TOKEN_AUTH_HEADER = "X-Auth-Token"
 
     # Authenticate against the service.
     #
     # Calling this method will try to create new session on the service using
-    # provided credentials. If the session creation fails, {AuthError} will be
-    # raised.
+    # provided credentials. If the session creation fails, basic
+    # authentication will be attempted. If basic authentication fails,
+    # {AuthError} will be raised.
     #
     # @param username [String] username
     # @param password [String] password
     # @raise [AuthError] if user session could not be created
     def login(username, password)
-      r = self.Links.Sessions.post(
-        payload: { "UserName" => username, "Password" => password }
-      )
-      raise AuthError unless r.status == 201
-
-      logout
-      rdata = r.data
-      @connector.add_headers(AUTH_HEADER => rdata[:headers][AUTH_HEADER])
-      @session = Resource.new(@connector, content: JSON.parse(rdata[:body]))
+      # Since session auth is more secure, we try it first and use basic auth
+      # only if session auth is not available.
+      if session_login_available?
+        session_login(username, password)
+      else
+        basic_login(username, password)
+      end
     end
 
     # Sign out of the service.
     #
     # If the session could not be deleted, {AuthError} will be raised.
     def logout
-      return unless @session
-      r = @session.delete
-      raise AuthError unless r.status == 204
-      @session = nil
-      @connector.remove_headers([AUTH_HEADER])
+      session_logout
+      basic_logout
     end
 
     # Find Redfish service object by OData ID field.
@@ -50,6 +48,48 @@ module RedfishClient
     # @return [Resource] new resource
     def find(oid)
       Resource.new(@connector, oid: oid)
+    end
+
+    private
+
+    def session_login_available?
+      !@content.dig("Links", "Sessions").nil?
+    end
+
+    def session_login(username, password)
+      r = self.Links.Sessions.post(
+        payload: { "UserName" => username, "Password" => password }
+      )
+      raise AuthError, "Invalid credentials" unless r.status == 201
+
+      session_logout
+
+      payload = r.data[:headers][TOKEN_AUTH_HEADER]
+      @connector.add_headers(TOKEN_AUTH_HEADER => payload)
+      @session = Resource.new(@connector, content: JSON.parse(r.data[:body]))
+    end
+
+    def session_logout
+      return unless @session
+      r = @session.delete
+      raise AuthError unless r.status == 204
+      @session = nil
+      @connector.remove_headers([TOKEN_AUTH_HEADER])
+    end
+
+    def auth_test_path
+      @content.values.map { |v| v["@odata.id"] }.compact.first
+    end
+
+    def basic_login(username, password)
+      payload = Base64.encode64("#{username}:#{password}").strip
+      @connector.add_headers(BASIC_AUTH_HEADER => "Basic #{payload}")
+      r = @connector.get(auth_test_path)
+      raise AuthError, "Invalid credentials" unless r.status == 200
+    end
+
+    def basic_logout
+      @connector.remove_headers([BASIC_AUTH_HEADER])
     end
   end
 end

--- a/spec/redfish_client/root_spec.rb
+++ b/spec/redfish_client/root_spec.rb
@@ -37,6 +37,18 @@ RSpec.describe RedfishClient::Root do
       { status: 200, body: { "key" => "val" }.to_json }
     )
     Excon.stub(
+      { path: "/basic_root" },
+      { status: 200, body: { "res" => { "@odata.id" => "/basic" } }.to_json }
+    )
+    Excon.stub(
+      { path: "/basic" },
+      { status: 401, body: { "error" => "no auth" }.to_json }
+    )
+    Excon.stub(
+      { path: "/basic", headers: { "Authorization" => "Basic dXNlcjpwYXNz" } },
+      { status: 200, body: { "key" => "basic_val" }.to_json }
+    )
+    Excon.stub(
       { path: "/find" },
       { status: 200, body: { "find" => "resource" }.to_json }
     )
@@ -46,23 +58,46 @@ RSpec.describe RedfishClient::Root do
     Excon.stubs.clear
   end
 
+  context "with sessions" do
+    let(:connector) { RedfishClient::Connector.new("http://example.com") }
+    subject { described_class.new(connector, oid: "/") }
+    before { subject.login("user", "pass") }
+
+    context "#login" do
+      it "authenticates user against service" do
+        expect(subject.Auth.key).to eq("val")
+      end
+    end
+
+    context "#logout" do
+      it "terminates user session" do
+        subject.logout
+        expect { subject.Auth }.to raise_error(Excon::Error::StubNotFound)
+      end
+    end
+  end
+
+  context "without sessions" do
+    let(:connector) { RedfishClient::Connector.new("http://example.com") }
+    subject { described_class.new(connector, oid: "/basic_root") }
+    before { subject.login("user", "pass") }
+
+    context "#login" do
+      it "authenticates user against service" do
+        expect(subject.res.key).to eq("basic_val")
+      end
+    end
+
+    context "#logout" do
+      it "terminates user session" do
+        subject.logout
+        expect(subject.res.error).to eq("no auth")
+      end
+    end
+  end
+
   let(:connector) { RedfishClient::Connector.new("http://example.com") }
   subject { described_class.new(connector, oid: "/") }
-
-  context "#login" do
-    it "authenticates user against service" do
-      subject.login("user", "pass")
-      expect(subject.Auth.key).to eq("val")
-    end
-  end
-
-  context "#logout" do
-    it "terminates user session" do
-      subject.login("user", "pass")
-      subject.logout
-      expect { subject.Auth }.to raise_error(Excon::Error::StubNotFound)
-    end
-  end
 
   context "#find" do
     it "fetches resource by OData id" do


### PR DESCRIPTION
Up until now, Redfish client only supported session authentication,
since it is mandatory as per Redfish standard [1]. This means that
client can interact with any Redfish-compliant service.

Unfortunately, services in the wild often only implement part of the
standard and in case of authentication, some of the services only
offer basic authentication, which makes our client useless for such
cases.

To bypass this, we added basic authentication support. By default, we
try to use session authentication if possible, since it is more secure
of the two, and only use basic authentication if session cannot be
created.

[1] http://redfish.dmtf.org/schemas/DSP0266_1.4.0.html#authentication