### PR TITLE
Properly isolate test cases

### DIFF
--- a/spec/redfish_client/connector_spec.rb
+++ b/spec/redfish_client/connector_spec.rb
@@ -36,47 +36,47 @@ RSpec.describe RedfishClient::Connector do
     Excon.stubs.clear
   end
 
-  subject { described_class.new("http://example.com") }
+  subject(:connector) { described_class.new("http://example.com") }
 
   context "#get" do
     it "returns response instance" do
-      expect(subject.get("/")).to be_a Excon::Response
+      expect(connector.get("/")).to be_a Excon::Response
     end
 
     it "keeps host stored" do
-      expect(subject.get("/missing").status).to eq(404)
-      expect(subject.get("/forbidden").status).to eq(403)
-      expect(subject.get("/").status).to eq(200)
+      expect(connector.get("/missing").status).to eq(404)
+      expect(connector.get("/forbidden").status).to eq(403)
+      expect(connector.get("/").status).to eq(200)
     end
   end
 
   context "#post" do
     it "returns response instance" do
-      expect(subject.post("/post")).to be_a Excon::Response
+      expect(connector.post("/post")).to be_a Excon::Response
     end
 
     it "send post request" do
-      expect(subject.post("/post", '{"key": "value"}').status).to eq(201)
+      expect(connector.post("/post", '{"key": "value"}').status).to eq(201)
     end
   end
 
   context "#patch" do
     it "returns response instance" do
-      expect(subject.patch("/patch")).to be_a Excon::Response
+      expect(connector.patch("/patch")).to be_a Excon::Response
     end
 
     it "send post request" do
-      expect(subject.patch("/patch", '{"key": "value"}').status).to eq(202)
+      expect(connector.patch("/patch", '{"key": "value"}').status).to eq(202)
     end
   end
 
   context "#delete" do
     it "returns response instance" do
-      expect(subject.delete("/delete")).to be_a Excon::Response
+      expect(connector.delete("/delete")).to be_a Excon::Response
     end
 
     it "send post request" do
-      expect(subject.delete("/delete").status).to eq(204)
+      expect(connector.delete("/delete").status).to eq(204)
     end
   end
 end

--- a/spec/redfish_client/resource_spec.rb
+++ b/spec/redfish_client/resource_spec.rb
@@ -41,181 +41,184 @@ RSpec.describe RedfishClient::Resource do
     Excon.stubs.clear
   end
 
-  let(:connector) { RedfishClient::Connector.new("http://example.com") }
+  subject(:resource) do
+    connector = RedfishClient::Connector.new("http://example.com")
+    described_class.new(connector, oid: "/")
+  end
 
   context ".new" do
     it "wraps hash content" do
       b = { "sample" => "data" }
-      r = described_class.new(connector, content: b)
+      r = described_class.new(nil, content: b)
       expect(r.raw).to eq(b)
     end
 
     it "fetches resource from oid" do
+      connector = RedfishClient::Connector.new("http://example.com")
       r = described_class.new(connector, oid: "/sub")
       expect(r.raw).to eq("@odata.id" => "/sub", "x" => "y")
     end
 
     it "add resource oid if missing" do
+      connector = RedfishClient::Connector.new("http://example.com")
       r = described_class.new(connector, oid: "/sub1")
       expect(r.raw).to eq("@odata.id" => "/sub1", "w" => "z")
     end
   end
 
-  subject { described_class.new(connector, oid: "/") }
-
   context "#[]" do
     it "retrieves key from resource" do
-      expect(subject["key"]).to eq("value")
+      expect(resource["key"]).to eq("value")
     end
 
     it "indexes into members" do
-      expect(subject[0].raw).to eq("@odata.id" => "/sub", "x" => "y")
+      expect(resource[0].raw).to eq("@odata.id" => "/sub", "x" => "y")
     end
 
     it "indexes into members with missing odata id" do
-      expect(subject[1].raw).to eq("@odata.id" => "/sub1", "w" => "z")
+      expect(resource[1].raw).to eq("@odata.id" => "/sub1", "w" => "z")
     end
 
     it "loads subresources on demand" do
-      expect(subject["data"]).to be_a described_class
+      expect(resource["data"]).to be_a described_class
     end
 
     it "errors out on missing key" do
-      expect { subject["missing"] }.to raise_error(KeyError)
+      expect { resource["missing"] }.to raise_error(KeyError)
     end
 
     it "errors out on indexing non-collection" do
-      expect { subject[0][0] }.to raise_error(KeyError)
+      expect { resource[0][0] }.to raise_error(KeyError)
     end
 
     it "errors out on index out of range" do
-      expect { subject[3] }.to raise_error(IndexError)
+      expect { resource[3] }.to raise_error(IndexError)
     end
   end
 
   context "#key?" do
     it "returns true for existing symbol" do
-      expect(subject.key?(:data)).to be true
+      expect(resource.key?(:data)).to be true
     end
 
     it "returns true for existing string" do
-      expect(subject.key?("data")).to be true
+      expect(resource.key?("data")).to be true
     end
 
     it "returns false for missing symbol" do
-      expect(subject.key?(:missing)).to be false
+      expect(resource.key?(:missing)).to be false
     end
 
     it "returns false for missing string" do
-      expect(subject.key?("missing")).to be false
+      expect(resource.key?("missing")).to be false
     end
   end
 
   context "#method_missing" do
     it "retrieves key from resource" do
-      expect(subject.key).to eq("value")
+      expect(resource.key).to eq("value")
     end
 
     it "loads subresources on demand" do
-      expect(subject.data).to be_a described_class
+      expect(resource.data).to be_a described_class
     end
 
     it "errors out on missing key" do
-      expect { subject.missing }.to raise_error(NoMethodError)
+      expect { resource.missing }.to raise_error(NoMethodError)
     end
   end
 
   context "#respond_to?" do
     it "returns true when accessing existing key" do
-      expect(subject.respond_to?("data")).to eq(true)
+      expect(resource.respond_to?("data")).to eq(true)
     end
 
     it "returns false when accessing non-existing key" do
-      expect(subject.respond_to?("bad")).to eq(false)
+      expect(resource.respond_to?("bad")).to eq(false)
     end
   end
 
   context "#raw" do
     it "returns raw wrapped data" do
-      expect(subject[0].raw).to eq("@odata.id" => "/sub", "x" => "y")
+      expect(resource[0].raw).to eq("@odata.id" => "/sub", "x" => "y")
     end
 
     it "returns raw wrapped data with added oid" do
-      expect(subject[1].raw).to eq("@odata.id" => "/sub1", "w" => "z")
+      expect(resource[1].raw).to eq("@odata.id" => "/sub1", "w" => "z")
     end
   end
 
   context "#to_s" do
     it "dumps content to json" do
-      expect(JSON.parse(subject[0].to_s)).to eq(subject[0].raw)
+      expect(JSON.parse(resource[0].to_s)).to eq(resource[0].raw)
     end
   end
 
   context "#reset" do
     it "clears cached entries" do
-      expect(subject.reset).to eq({})
+      expect(resource.reset).to eq({})
     end
   end
 
   context "#post" do
     it "returns response instance" do
-      expect(subject.post).to be_a Excon::Response
+      expect(resource.post).to be_a Excon::Response
     end
 
     it "posts data to the @odata.id endpoint by default" do
-      expect(subject.post.status).to eq(201)
+      expect(resource.post.status).to eq(201)
     end
 
     it "posts data to the selected field content" do
-      expect(subject.post(field: "alt_path").status).to eq(202)
+      expect(resource.post(field: "alt_path").status).to eq(202)
     end
 
     it "posts data to the selected path" do
-      expect(subject.post(path: "/mis").status).to eq(404)
+      expect(resource.post(path: "/mis").status).to eq(404)
     end
 
     it "posts data to the path in presence of field" do
-      expect(subject.post(field: "alt_path", path: "/mis").status).to eq(404)
+      expect(resource.post(field: "alt_path", path: "/mis").status).to eq(404)
     end
 
     it "posts data to the selected path" do
-      expect(subject.post(path: "/missing").status).to eq(404)
+      expect(resource.post(path: "/missing").status).to eq(404)
     end
   end
 
   context "#patch" do
     it "returns response instance" do
-      expect(subject.patch).to be_a Excon::Response
+      expect(resource.patch).to be_a Excon::Response
     end
 
     it "posts data to the @odata.id endpoint by default" do
-      expect(subject.patch.status).to eq(401)
+      expect(resource.patch.status).to eq(401)
     end
 
     it "posts data to the selected field content" do
-      expect(subject.patch(field: "alt_path").status).to eq(400)
+      expect(resource.patch(field: "alt_path").status).to eq(400)
     end
 
     it "posts data to the selected path" do
-      expect(subject.patch(path: "/mis").status).to eq(404)
+      expect(resource.patch(path: "/mis").status).to eq(404)
     end
 
     it "posts data to the path in presence of field" do
-      expect(subject.patch(field: "alt_path", path: "/mis").status).to eq(404)
+      expect(resource.patch(field: "alt_path", path: "/mis").status).to eq(404)
     end
 
     it "posts data to the selected path" do
-      expect(subject.patch(path: "/missing").status).to eq(404)
+      expect(resource.patch(path: "/missing").status).to eq(404)
     end
   end
 
   context "#delete" do
     it "returns response instance" do
-      expect(subject.delete).to be_a Excon::Response
+      expect(resource.delete).to be_a Excon::Response
     end
 
     it "posts data to the external endpoint" do
-      expect(subject.delete.status).to eq(204)
+      expect(resource.delete.status).to eq(204)
     end
   end
 end

--- a/spec/redfish_client/root_spec.rb
+++ b/spec/redfish_client/root_spec.rb
@@ -58,50 +58,52 @@ RSpec.describe RedfishClient::Root do
     Excon.stubs.clear
   end
 
+  subject(:root) do
+    connector = RedfishClient::Connector.new("http://example.com")
+    described_class.new(connector, oid: "/")
+  end
+
   context "with sessions" do
-    let(:connector) { RedfishClient::Connector.new("http://example.com") }
-    subject { described_class.new(connector, oid: "/") }
-    before { subject.login("user", "pass") }
+    before { root.login("user", "pass") }
 
     context "#login" do
       it "authenticates user against service" do
-        expect(subject.Auth.key).to eq("val")
+        expect(root.Auth.key).to eq("val")
       end
     end
 
     context "#logout" do
       it "terminates user session" do
-        subject.logout
-        expect { subject.Auth }.to raise_error(Excon::Error::StubNotFound)
+        root.logout
+        expect { root.Auth }.to raise_error(Excon::Error::StubNotFound)
       end
     end
   end
 
   context "without sessions" do
-    let(:connector) { RedfishClient::Connector.new("http://example.com") }
-    subject { described_class.new(connector, oid: "/basic_root") }
-    before { subject.login("user", "pass") }
+    subject(:root) do
+      connector = RedfishClient::Connector.new("http://example.com")
+      described_class.new(connector, oid: "/basic_root")
+    end
+    before { root.login("user", "pass") }
 
     context "#login" do
       it "authenticates user against service" do
-        expect(subject.res.key).to eq("basic_val")
+        expect(root.res.key).to eq("basic_val")
       end
     end
 
     context "#logout" do
       it "terminates user session" do
-        subject.logout
-        expect(subject.res.error).to eq("no auth")
+        root.logout
+        expect(root.res.error).to eq("no auth")
       end
     end
   end
 
-  let(:connector) { RedfishClient::Connector.new("http://example.com") }
-  subject { described_class.new(connector, oid: "/") }
-
   context "#find" do
     it "fetches resource by OData id" do
-      res = subject.find("/find")
+      res = root.find("/find")
       expect(res.raw).to eq("find" => "resource", "@odata.id" => "/find")
     end
   end


### PR DESCRIPTION
In order to completely decouple test cases, we removed the shared state from the test suite and named the test subjects explicitly.

Implements changes promised in #2 