### PR TITLE
Add tests for client creation helper

### DIFF
--- a/spec/redfish_client_spec.rb
+++ b/spec/redfish_client_spec.rb
@@ -1,7 +1,39 @@
 # frozen_string_literal: true
 
+require "json"
+
+require "redfish_client"
+
 RSpec.describe RedfishClient do
+  before(:all) do
+    Excon.defaults[:mock] = true
+    Excon.stub(
+      { path: "/redfish/v1" },
+      { status: 200, body: { "key" => "default_val" }.to_json }
+    )
+    Excon.stub(
+      { path: "/custom" },
+      { status: 200, body: { "key" => "custom_val" }.to_json }
+    )
+  end
+
+  after(:all) do
+    Excon.stubs.clear
+  end
+
   it "has a version number" do
     expect(RedfishClient::VERSION).not_to be nil
+  end
+
+  context ".new" do
+    it "creates new root resource with default prefix" do
+      client = described_class.new("http://example.com")
+      expect(client.key).to eq("default_val")
+    end
+
+    it "creates new root resource with custom prefix" do
+      client = described_class.new("http://example.com", prefix: "/custom")
+      expect(client.key).to eq("custom_val")
+    end
   end
 end


### PR DESCRIPTION
This is the only remaining part of the codebase that was not covered
by tests.