### PR TITLE
Add various badges for project tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Redfish Ruby Client
 
+[![Build Status](https://travis-ci.org/xlab-si/redfish_client.svg?branch=master)](https://travis-ci.org/xlab-si/redfish_client)
+[![Maintainability](https://api.codeclimate.com/v1/badges/ce990310be22db90c3e2/maintainability)](https://codeclimate.com/github/xlab-si/redfish_client/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/ce990310be22db90c3e2/test_coverage)](https://codeclimate.com/github/xlab-si/redfish_client/test_coverage)
+[![Dependency Status](https://beta.gemnasium.com/badges/github.com/xlab-si/redfish_client.svg)](https://beta.gemnasium.com/projects/github.com/xlab-si/redfish_client)
+[![security](https://hakiri.io/github/xlab-si/redfish_client/master.svg)](https://hakiri.io/github/xlab-si/redfish_client/master)
+
+
 This repository contains source code for redfish_client gem that can be used
 to connect to Redfish services.
 


### PR DESCRIPTION
Currently, Project is checked by four different services:

 1. Travis CI runs our tests and generates test coverage reports.
 2. Code Climate runs code quality tests and displays test coverage.
 3. Gemnasium checks for any outdated dependencies.
 4. Hakiri scans our library and dependencies for presence of publicly
    reported vulnerabilities.