### PR TITLE
Get rid of GET call to Sessions endpoint

### DIFF
--- a/lib/redfish_client/root.rb
+++ b/lib/redfish_client/root.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "base64"
+require "json"
 require "redfish_client/resource"
 
 module RedfishClient
@@ -57,8 +58,9 @@ module RedfishClient
     end
 
     def session_login(username, password)
-      r = self.Links.Sessions.post(
-        payload: { "UserName" => username, "Password" => password }
+      r = @connector.post(
+        @content["Links"]["Sessions"]["@odata.id"],
+        { "UserName" => username, "Password" => password }.to_json
       )
       raise AuthError, "Invalid credentials" unless r.status == 201
 

--- a/spec/redfish_client/root_spec.rb
+++ b/spec/redfish_client/root_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe RedfishClient::Root do
     )
     Excon.stub(
       { path: "/sess",
-        method: :get },
+        method: :get,
+        headers: { "Authorization" => "Basic dXNlcjpwYXNz" } },
       { status: 200,
         body: { "@odata.id": "/sess" }.to_json }
     )


### PR DESCRIPTION
Up until now, we created new session authentication token by
retrieving the Sessions resource and posting credentials through this
resource to obtain the authentication token. But this is not a viable
strategy, since standard [1] mandates that Sessions endpoint is only
available when authenticated, exception being the POST requests.

This commit fixes the login functionality by bypassing the resource
fetching mechanism and issuing a POST request directly to the Sessions
endpoint. Tests were also updated to follow the standard better.

[1] http://redfish.dmtf.org/schemas/DSP0266_1.4.0.html#http-header-security