### PR TITLE
Make resource initialization more robust

### DIFF
--- a/spec/redfish_client/resource_spec.rb
+++ b/spec/redfish_client/resource_spec.rb
@@ -104,6 +104,12 @@ RSpec.describe RedfishClient::Resource do
       r = described_class.new(connector, oid: "/sub1")
       expect(r.raw).to eq("@odata.id" => "/sub1", "w" => "z")
     end
+
+    it "errors out on service error" do
+      connector = RedfishClient::Connector.new("http://example.com")
+      expect { described_class.new(connector, oid: "/missing") }
+        .to raise_error(RedfishClient::Resource::NoResource)
+    end
   end
 
   context "#[]" do

--- a/spec/redfish_client/root_spec.rb
+++ b/spec/redfish_client/root_spec.rb
@@ -97,7 +97,8 @@ RSpec.describe RedfishClient::Root do
     context "#logout" do
       it "terminates user session" do
         root.logout
-        expect(root.res.error).to eq("no auth")
+        expect { root.res.error }
+          .to raise_error(RedfishClient::Resource::NoResource)
       end
     end
   end


### PR DESCRIPTION
Up until now, when the service returned non-OK status, we simply
ignored it and attempted resource construction anyway, which usually
ended with an obscure JSON-related error.

To remedy this situation, we refactored the resource initialization.
New initialization will now raise an exception when the service
returns status other than 200.