### PR TITLE
Expose resource response headers via accessor

### DIFF
--- a/lib/redfish_client/resource.rb
+++ b/lib/redfish_client/resource.rb
@@ -28,6 +28,9 @@ module RedfishClient
     # resource.
     class NoResource < StandardError; end
 
+    # Headers, returned from the service when resource has been constructed.
+    attr_reader :headers
+
     # Create new resource.
     #
     # Resource can be created either by passing in OpenData identifier or

--- a/spec/redfish_client/resource_spec.rb
+++ b/spec/redfish_client/resource_spec.rb
@@ -271,4 +271,10 @@ RSpec.describe RedfishClient::Resource do
       expect(resource.delete.status).to eq(204)
     end
   end
+
+  context "#headers" do
+    it "returns response headers, set at init time" do
+      expect(resource.headers).to eq({})
+    end
+  end
 end


### PR DESCRIPTION
Having access to response headers might be useful in some cases. And
since we are already storing them, exposing them to the public gives
end-user some additional flexibility almost for free.