### PR TITLE
Make find method return nil on error

### DIFF
--- a/lib/redfish_client/root.rb
+++ b/lib/redfish_client/root.rb
@@ -46,8 +46,19 @@ module RedfishClient
     # Find Redfish service object by OData ID field.
     #
     # @param oid [String] Odata id of the resource
-    # @return [Resource] new resource
+    # @return [Resource, nil] new resource or nil if resource cannot be found
     def find(oid)
+      find!(oid)
+    rescue NoResource
+      nil
+    end
+
+    # Find Redfish service object by OData ID field.
+    #
+    # @param oid [String] Odata id of the resource
+    # @return [Resource] new resource
+    # @raise [NoResource] resource cannot be fetched
+    def find!(oid)
       Resource.new(@connector, oid: oid)
     end
 

--- a/spec/redfish_client/root_spec.rb
+++ b/spec/redfish_client/root_spec.rb
@@ -108,5 +108,21 @@ RSpec.describe RedfishClient::Root do
       res = root.find("/find")
       expect(res.raw).to eq("find" => "resource", "@odata.id" => "/find")
     end
+
+    it "returns nil on error" do
+      expect(root.find("/basic")).to be_nil
+    end
+  end
+
+  context "#find!" do
+    it "fetches resource by OData id" do
+      res = root.find!("/find")
+      expect(res.raw).to eq("find" => "resource", "@odata.id" => "/find")
+    end
+
+    it "raises exception on error" do
+      expect { root.find!("/basic") }
+          .to raise_error(RedfishClient::Resource::NoResource)
+    end
   end
 end


### PR DESCRIPTION
Returning nil instead of raising an exception makes it a bit easier to
handle the error condition in situations where the end-user does not
care much about the reasons behind the failure.

For those who do care, we added new method find! that raises an
exception.