### PR TITLE
Make library interface more similar to Ruby classes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,10 @@ AllCops:
 Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
 
+Style/MethodMissing:
+  Exclude:
+    - lib/redfish_client/resource.rb
+
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 

--- a/spec/redfish_client/resource_spec.rb
+++ b/spec/redfish_client/resource_spec.rb
@@ -129,16 +129,58 @@ RSpec.describe RedfishClient::Resource do
       expect(resource["data"]).to be_a described_class
     end
 
-    it "errors out on missing key" do
-      expect { resource["missing"] }.to raise_error(KeyError)
+    it "returns nil on missing key" do
+      expect(resource["missing"]).to be_nil
     end
 
     it "errors out on indexing non-collection" do
       expect { resource[0][0] }.to raise_error(KeyError)
     end
 
-    it "errors out on index out of range" do
-      expect { resource[3] }.to raise_error(IndexError)
+    it "returns nil when index is out of range" do
+      expect(resource[3]).to be_nil
+    end
+  end
+
+  context "#dig" do
+    it "retrieves key from resource" do
+      expect(resource.dig("key")).to eq("value")
+    end
+
+    it "indexes into members" do
+      expect(resource.dig(0).raw).to eq("@odata.id" => "/sub", "x" => "y")
+    end
+
+    it "indexes into members with missing odata id" do
+      expect(resource.dig(1).raw).to eq("@odata.id" => "/sub1", "w" => "z")
+    end
+
+    it "loads subresources on demand" do
+      expect(resource.dig("data")).to be_a described_class
+    end
+
+    it "returns nil on missing key" do
+      expect(resource.dig("missing")).to be_nil
+    end
+
+    it "returns nil when index is out of range" do
+      expect(resource.dig(3)).to be_nil
+    end
+
+    it "loads nested keys" do
+      expect(resource.dig("data", "a")).to eq("b")
+    end
+
+    it "loads nested keys and indices" do
+      expect(resource.dig(0, "x")).to eq("y")
+    end
+
+    it "skips any keys after first nil value" do
+      expect(resource.dig(4, "a", "b", 3)).to be_nil
+    end
+
+    it "errors out on indexing non-collection" do
+      expect { resource.dig(0, 0) }.to raise_error(KeyError)
     end
   end
 
@@ -169,8 +211,8 @@ RSpec.describe RedfishClient::Resource do
       expect(resource.data).to be_a described_class
     end
 
-    it "errors out on missing key" do
-      expect { resource.missing }.to raise_error(NoMethodError)
+    it "returns nil on missing key" do
+      expect(resource.missing).to be_nil
     end
   end
 

--- a/spec/redfish_client/root_spec.rb
+++ b/spec/redfish_client/root_spec.rb
@@ -97,8 +97,7 @@ RSpec.describe RedfishClient::Root do
     context "#logout" do
       it "terminates user session" do
         root.logout
-        expect { root.res.error }
-          .to raise_error(RedfishClient::Resource::NoResource)
+        expect(root.res).to be_nil
       end
     end
   end


### PR DESCRIPTION
Up until now, most of the error handling that the end user was
required to do was in a form of rescuing from a few exceptions that
Redfish client would raise.

On the other hand, most of the Ruby's built-in classes raise usually
indicate an error by returning nil value instead. To be more specific,
hashes and arrays return nil if we are trying to access some
non-existing or out-of-bounds value.

Since our classes mimic previously described classes, we made some
changes to the interface that should make them a bit easier to use in
existing codebases that follow standard Ruby conventions.

Main changes are:

 1. [] method returns nil when key is missing or index is
    out-of-bounds for collections.
 2. method_missing simply delegates work to [].

Second change allows library consumer to use Ruby's safe navigation
operator, making accessing deeply nested values way less verbose. Let
us take the following example:

    return nil unless obj.key?("k1")
    return nil unless obj.k1.key?("k2")
    obj.k1.k2

Using newly introduced changes, this can be rewritten into

    obj.k1&.k2

For more info, see the client documentation.