### PR TITLE
Use the same version of rubocop in CI and locally

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,3 +1,4 @@
 plugins:
   rubocop:
     enabled: true
+    channel: rubocop-0-54

--- a/redfish_client.gemspec
+++ b/redfish_client.gemspec
@@ -36,6 +36,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", ">= 3.7"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "yard"
-  spec.add_development_dependency "rubocop"
+  spec.add_development_dependency "rubocop", "~> 0.54.0"
   spec.add_development_dependency "pry"
 end


### PR DESCRIPTION
Debugging package issues can be a bit frustrating if the CI machinery
is running a different versions of helper tools, since configuration
can and do change as the tools mature.

This commit gets rubocop versions on the CI and in the local
development machine back in sync by pinning the version in gemfile and
explicitly specifying the channel to use on CodeClimate.